### PR TITLE
request.error related to content-length header

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,7 +200,7 @@ AlchemyAPI.prototype._getQuery = function(data, opts, method) {
 	else {
 		query.post = {html: data};
 		query.headers = {
-			 'content-length': '' + data.length + ''
+			 'content-length': '' + querystring.stringify(query.post).length + ''
 			,'content-type': 'application/x-www-form-urlencoded'
 		};
 		//console.log("======================3==================");


### PR DESCRIPTION
The content length header was inaccurate before if the content being sent was HTML. since the length would, like non-HTML, be the stringified length of the `query.post`, this needed to be updated so that ParseErrors weren't thrown.
