### PR TITLE
Basic Implementation for GetAPIKeyInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,3 +238,15 @@ Publication Date
 
       // Do something with data
     });
+    
+API Key Information
+----------
+    var AlchemyAPI = require('alchemy-api');
+    var alchemy = new AlchemyAPI('<YOUR API KEY>');
+    alchemy.apiKeyInfo({}, function(err, response) {
+      if (err) throw err;
+
+      // Do something with data
+      console.log('Status:', response.status, 'Consumed:', response.consumedDailyTransactions, 'Limit:', response.dailyTransactionLimit);
+      
+    });

--- a/index.js
+++ b/index.js
@@ -208,6 +208,28 @@ AlchemyAPI.prototype._getQuery = function(data, opts, method) {
 };
 
 /**
+ * Function to return the API key usage information
+ * @param  {Object} options Options to be passed to the AlchemyAPI (no options are currently supported)
+ * @param cb
+ */
+AlchemyAPI.prototype.apiKeyInfo = function(options, cb) {
+	// Since this request is nothing like the others, build it manually
+	var opts = extend(this.options, opts),
+		query = {
+			data: "",
+			post: {},
+			apimethod: "info/GetAPIKeyInfo",
+			headers: {
+				"content-length": 0
+			}
+		};
+	query.nice = this._generateNiceUrl(null, opts, query.apimethod)
+	query.nice.method = "GET";
+	query.nice.headers = query.headers;
+	this._doRequest(query, cb)
+};
+
+/**
  * Function to return sentiment of the data passed in
  * @param  {String} data The text to be passed to Alchemy can either a url, html text or plain text 
  * @param  {Object} options Options to be passed to the AlchemyAPI (no options are currently supported) 

--- a/test/index.js
+++ b/test/index.js
@@ -23,6 +23,19 @@ module.exports = {
 		test.equal(alchemy._urlCheck('http://google.com is my favorite site ever'), false);
 		test.done();
 	},
+	'get api key info': function(test) {
+		var alchemy = new Alchemy(apikey);
+		alchemy.apiKeyInfo({}, function(error, result) {
+			test.ifError(error);
+			test.ok(result);
+			test.ok(result.hasOwnProperty('status'));
+			test.ok(result.hasOwnProperty('consumedDailyTransactions'));
+			test.ok(result.hasOwnProperty('dailyTransactionLimit'));
+			//console.log(result.docSentiment);
+			//test.deepEqual(result.status, "OK");
+			test.done();
+		});
+	},
 	'get sentiment': function(test) {
 		var alchemy = new Alchemy(apikey);
 	        alchemy.sentiment(testURL, {}, function(error, result) {


### PR DESCRIPTION
Greetings,

This request adds support for the `GetAPIKeyInfo` api call, which just simply returns the API key usage information.

Also included are unit tests to support it and example docs.