### PR TITLE
Corrected a typo in Targeted Sentiment Analysis section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Targeted Sentiment Analysis
 ------------------
     var AlchemyAPI = require('alchemy-api');
     var alchemy = new AlchemyAPI('<YOUR API KEY>');
-    alchemy.sentiment_targeted('<URL|HTML|TEXT>', '<Target>', {}, function(err, response) {
+    alchemy.sentiment_targeted('<URL|HTML|TEXT>', '<Target>', function(err, response) {
       if (err) throw err;
 
       // See http://www.alchemyapi.com/api/sentiment/htmlc.html for format of returned object


### PR DESCRIPTION
Corrected a typo within the Targeted Sentiment Analysis section of the README. Removed the '{}' parameter, which in the TSA section was replaced by TARGET.