### PR TITLE
Modified api_url to reflect the upcoming migration of the old Alchemy…

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var imageType = require('image-type');
 var AlchemyAPI = function(api_key, opts) {
 	var settings = {
 		 format: "json"
-		,api_url: "access.alchemyapi.com"
+		,api_url: "gateway-a.watsonplatform.net"
 		,protocol: "http"
 	};
 	


### PR DESCRIPTION
…API endpoint to the IBM Bluemix platform.

The AlchemyAPI documentation has changed to point to a new base URL (http://www.alchemyapi.com/api/calling-the-api) on IBM's Bluemix platform.  Although we've found that both endpoints are working at the moment this change keeps the library up to date with the documentation and should future proof it in case the old URL gets deprecated.