### PR TITLE
Change default protocol to HTTPS

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var AlchemyAPI = function(api_key, opts) {
 	var settings = {
 		 format: "json"
 		,api_url: "gateway-a.watsonplatform.net"
-		,protocol: "http"
+		,protocol: "https"
 	};
 	
 	settings = extend(settings, opts);


### PR DESCRIPTION
[IBM / AlchemyAPI is deprecating HTTP access on November 9, 2016.](https://www.dropbox.com/s/w3vfa7ydjeghd3x/Screenshot%202016-08-26%2015.05.23.png?dl=0)

This PR simply changes the default protocol from HTTP to HTTPS.
